### PR TITLE
FIX: keyUsage

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/req.j2
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/req.j2
@@ -12,7 +12,7 @@ O = Quay
 OU = Division
 CN = {{ quay_hostname.split(":")[0] if (":" in quay_hostname) else quay_hostname }}
 [v3_req]
-keyUsage = keyEncipherment, dataEncipherment
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
 subjectAltName = @alt_names
 [alt_names]


### PR DESCRIPTION
The current `keyUsage = keyEncipherment, dataEncipherment` is causing `ERR_SSL_KEY_USAGE_INCOMPATIBLE` error with chrome. This fix modifies to `nonRepudiation, digitalSignature, keyEncipherment`