### PR TITLE
feature: custom certificate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The following flags are also available:
 --targetUsername    -u  The user on the target host which will be used for SSH. This defaults to $USER
 --quayHostname          The value to set SERVER_HOSTNAME in the Quay config.yaml. This defaults to <targetHostname>:8443
 --initPassword          The password of the init user created during Quay installation.
+--sslCert               The path to the SSL certificate Quay should use
+--sslKey                The path to the SSL key
 --verbose           -v  Show debug logs and ansible playbook outputs
 ```
 

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-quay-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-quay-service.yaml
@@ -21,6 +21,18 @@
     src: ../templates/config.yaml.j2
     dest: /etc/quay-install/quay-config/config.yaml
 
+- name: Check if SSL Cert exists
+  stat:
+    path: /runner/certs/quay.cert
+  delegate_to: localhost
+  register: ssl_cert
+
+- name: Check if SSL Key exists
+  stat:
+    path: /runner/certs/quay.key
+  delegate_to: localhost
+  register: ssl_key
+
 - name: Create SSL Certs
   block:
     - name: Create CSR
@@ -30,16 +42,36 @@
 
     - name: Creating self-signed cert
       command: "openssl req -new -nodes -x509 -days 365 -keyout /etc/quay-install/quay-config/ssl.key -out /etc/quay-install/quay-config/ssl.cert -config /etc/quay-install/quay-config/req"
+  when: (ssl_cert.stat.exists == False) and (ssl_key.stat.exists == False)
 
+- name: Copy SSL Certs
+  block:
+    - name: Copy SSL certificate
+      copy:
+        src: /runner/certs/quay.cert
+        dest: /etc/quay-install/quay-config/ssl.cert
+
+    - name: Copy SSL key
+      copy:
+        src: /runner/certs/quay.key
+        dest: /etc/quay-install/quay-config/ssl.key
+  when: (ssl_cert.stat.exists == True) and (ssl_key.stat.exists == True)
+
+- name: Set certificate permissions
+  block:
     - name: Set permissions for key
       ansible.builtin.file:
         path: /etc/quay-install/quay-config/ssl.key
         mode: u=rw,g=r,o=r
+        owner: root
+        group: root
 
     - name: Set permissions for cert
       ansible.builtin.file:
         path: /etc/quay-install/quay-config/ssl.cert
         mode: u=rw,g=r,o=r
+        owner: root
+        group: root
 
 - name: Copy Quay systemd service file
   template:

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strconv"
 
 	_ "github.com/lib/pq" // pg driver
@@ -23,6 +24,12 @@ var imageArchivePath string
 
 // sshKey is the optional location of the SSH key you would like to use to connect to your host.
 var sshKey string
+
+// sslCert is the path to the SSL certitificate
+var sslCert string
+
+// sslKey is the path to the SSL key
+var sslKey string
 
 // targetHostname is the hostname of the server you wish to install Quay on
 var targetHostname string
@@ -60,6 +67,9 @@ func init() {
 	installCmd.Flags().StringVarP(&targetUsername, "targetUsername", "u", os.Getenv("USER"), "The user on the target host which will be used for SSH. This defaults to $USER")
 	installCmd.Flags().StringVarP(&sshKey, "ssh-key", "k", os.Getenv("HOME")+"/.ssh/quay_installer", "The path of your ssh identity key. This defaults to ~/.ssh/quay_installer")
 
+	installCmd.Flags().StringVarP(&sslCert, "sslCert", "", "", "The path to the SSL certificate Quay should use")
+	installCmd.Flags().StringVarP(&sslKey, "sslKey", "", "", "The path to the SSL key Quay should use")
+
 	installCmd.Flags().StringVarP(&initPassword, "initPassword", "", "", "The password of the initial user. If not specified, this will be randomly generated.")
 	installCmd.Flags().StringVarP(&quayHostname, "quayHostname", "", "", "The value to set SERVER_HOSTNAME in the Quay config.yaml. This defaults to <targetHostname>:8443")
 
@@ -80,6 +90,10 @@ func install() {
 
 	// Load execution environment
 	err = loadExecutionEnvironment()
+	check(err)
+
+	// Load custom certificates
+	err = loadCerts()
 	check(err)
 
 	// Check that SSH key is present, and generate if not
@@ -142,6 +156,20 @@ func install() {
 		askBecomePassFlag = "-K"
 	}
 
+	// Set the SSL flag if cert and key are defined
+	var sslCertKeyFlag string
+	if sslCert != "" && sslKey != "" {
+	sslCertAbs, err := filepath.Abs(sslCert)
+	if err != nil {
+		check(errors.New("Unable to get absolute path of " + sslCert))
+	}
+	sslKeyAbs, err := filepath.Abs(sslKey)
+	if err != nil {
+		check(errors.New("Unable to get absolute path of " + sslKey))
+	}
+		sslCertKeyFlag = fmt.Sprintf("-v %s:/runner/certs/quay.cert -v %s:/runner/certs/quay.key", sslCertAbs, sslKeyAbs)
+	}
+
 	// Run playbook
 	log.Printf("Running install playbook. This may take some time. To see playbook output run the installer with -v (verbose) flag.")
 	podmanCmd := fmt.Sprintf(`sudo podman run `+
@@ -149,6 +177,7 @@ func install() {
 		`--workdir /runner/project `+
 		`--net host `+
 		imageArchiveMountFlag+ // optional image archive flag
+		sslCertKeyFlag + // optional ssl cert/key flag
 		` -v %s:/runner/env/ssh_key `+
 		`-e RUNNER_OMIT_EVENTS=False `+
 		`-e RUNNER_ONLY_FAILED_EVENTS=False `+

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -159,7 +159,7 @@ func install() {
 	// Set the SSL flag if cert and key are defined
 	var sslCertKeyFlag string
 	if sslCert != "" && sslKey != "" {
-	sslCertAbs, err := filepath.Abs(sslCert)
+		sslCertAbs, err := filepath.Abs(sslCert)
 	if err != nil {
 		check(errors.New("Unable to get absolute path of " + sslCert))
 	}
@@ -177,7 +177,7 @@ func install() {
 		`--workdir /runner/project `+
 		`--net host `+
 		imageArchiveMountFlag+ // optional image archive flag
-		sslCertKeyFlag + // optional ssl cert/key flag
+		sslCertKeyFlag+ // optional ssl cert/key flag
 		` -v %s:/runner/env/ssh_key `+
 		`-e RUNNER_OMIT_EVENTS=False `+
 		`-e RUNNER_ONLY_FAILED_EVENTS=False `+


### PR DESCRIPTION
This PR implements the `--sslCert` and `--sslKey` command line options allowing to define a custom certificate for Quay