### PR TITLE
fix: offline image bundle

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 POSTGRES_IMAGE=docker.io/centos/postgresql-10-centos8
 QUAY_IMAGE=quay.io/projectquay/quay
 REDIS_IMAGE=docker.io/centos/redis-5-centos8
+PAUSE_IMAGE=registry.access.redhat.com/ubi8/pause:latest
 RELEASE_VERSION=v0.1.4

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,13 @@ build-image-archive:
 	sudo podman pull ${QUAY_IMAGE}
 	sudo podman pull ${REDIS_IMAGE}
 	sudo podman pull ${POSTGRES_IMAGE}
+	sudo podman pull ${PAUSE_IMAGE}
 	sudo podman save \
 	--multi-image-archive \
 	${QUAY_IMAGE} \
 	${REDIS_IMAGE} \
-	${POSTGRES_IMAGE}\
+	${POSTGRES_IMAGE} \
+	${PAUSE_IMAGE}\
 	> image-archive.tar
 
 


### PR DESCRIPTION
registry.access.redhat.com/ubi8/pause:latest is missing from the offline image bundle which will case the offline installation fail