### PR TITLE
Fix sslCert spacing

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -245,7 +245,7 @@ func install() {
 		if err != nil {
 			check(errors.New("Unable to get absolute path of " + sslKey))
 		}
-		sslCertKeyFlag = fmt.Sprintf("-v %s:/runner/certs/quay.cert:Z -v %s:/runner/certs/quay.key:Z", sslCertAbs, sslKeyAbs)
+		sslCertKeyFlag = fmt.Sprintf(" -v %s:/runner/certs/quay.cert:Z -v %s:/runner/certs/quay.key:Z", sslCertAbs, sslKeyAbs)
 	}
 
 	// Run playbook


### PR DESCRIPTION
Fixes #31 

* Adjust spacing of ssl options

Certs generated following Quay docs: https://access.redhat.com/documentation/en-us/red_hat_quay/2.9/html/manage_red_hat_quay/using-ssl-to-protect-quay

Validated by executing:
`openshift-mirror-registry install --initPassword password --quayHostname registry.steve-ml.net --sslCert certs/ssl.cert --sslKey certs/ssl.key --verbose`